### PR TITLE
Part 1: Add getRuntimeMode

### DIFF
--- a/src/shared/__tests__/get-runtime-mode.test.js
+++ b/src/shared/__tests__/get-runtime-mode.test.js
@@ -1,0 +1,62 @@
+// @flow
+import {getRuntimeMode} from "../get-runtime-mode.js";
+
+describe("#getRuntimeMode", () => {
+    const NODE_ENV = process.env.NODE_ENV;
+
+    afterEach(() => {
+        process.env.NODE_ENV = NODE_ENV;
+    });
+
+    it.each([
+        ["production", "prod"],
+        ["production", "production"],
+        ["development", "dev"],
+        ["development", "development"],
+        ["test", "test"],
+    ])("should return %s for given %s", (expectation, nodeEnv) => {
+        // Arrange
+        process.env.NODE_ENV = nodeEnv;
+
+        // Act
+        const result = getRuntimeMode("development");
+
+        // Assert
+        expect(result).toBe(expectation);
+    });
+
+    it.each([
+        ["production", undefined],
+        ["development", undefined],
+        ["production", "blah"],
+        ["development", "blah"],
+    ])("should return %s if NODE_ENV unrecognised", (expectation, nodeEnv) => {
+        // Arrange
+        process.env.NODE_ENV = nodeEnv;
+
+        // Act
+        const result = getRuntimeMode(expectation);
+
+        // Assert
+        expect(result).toBe(expectation);
+    });
+
+    it.each([
+        ["development", "development"],
+        ["production", "production"],
+        ["development", "test"],
+        ["production", "test"],
+    ])(
+        "should ignore default of %s and give precedent to NODE_ENV=%s",
+        (defaultValue, nodeEnv) => {
+            // Arrange
+            process.env.NODE_ENV = nodeEnv;
+
+            // Act
+            const result = getRuntimeMode(defaultValue);
+
+            // Assert
+            expect(result).toBe(nodeEnv);
+        },
+    );
+});

--- a/src/shared/get-runtime-mode.js
+++ b/src/shared/get-runtime-mode.js
@@ -1,0 +1,28 @@
+// @flow
+import type {Runtime} from "./types.js";
+
+/**
+ * Determine the node runtime mode.
+ *
+ * The mode is calculated from NODE_ENV. If NODE_ENV is not set or set to
+ * something other than expected values, the defaultMode is returned.
+ *
+ * @returns {Runtime} The runtime mode of production, development, or test.
+ */
+export const getRuntimeMode = (defaultMode: Runtime): Runtime => {
+    switch (process.env.NODE_ENV) {
+        case "test":
+            return "test";
+
+        case "production":
+        case "prod":
+            return "production";
+
+        case "development":
+        case "dev":
+            return "development";
+
+        default:
+            return defaultMode;
+    }
+};

--- a/src/shared/types.js
+++ b/src/shared/types.js
@@ -1,0 +1,2 @@
+// @flow
+export type Runtime = "production" | "test" | "development";


### PR DESCRIPTION
Learning from the original Phab diff, I'm doing things in small pieces.

This is the first piece of "shared" code. It determines a canonical runtime mode for NODE based off NODE_ENV. The `defaultValue` is where our Khan-specific customization will take `KA_IS_DEV_SERVER` into account.