### PR TITLE
Part 5: Add error logging middleware

### DIFF
--- a/src/shared/__tests__/make-error-middleware.test.js
+++ b/src/shared/__tests__/make-error-middleware.test.js
@@ -1,0 +1,40 @@
+//@flow
+import * as ExpressWinston from "express-winston";
+import {makeErrorMiddleware} from "../make-error-middleware.js";
+
+jest.mock("express-winston");
+
+describe("#makeErrorMiddleware", () => {
+    it("should return express-winston error logger", () => {
+        // Arrange
+        const pretendLogger = ({}: any);
+        const pretendErrorMiddleware = ({}: any);
+        jest.spyOn(ExpressWinston, "errorLogger").mockReturnValue(
+            pretendErrorMiddleware,
+        );
+
+        // Act
+        const result = makeErrorMiddleware(pretendLogger);
+
+        // Assert
+        expect(result).toBe(pretendErrorMiddleware);
+    });
+
+    it("should pass given logger to express winston", () => {
+        // Arrange
+        const pretendLogger = ({}: any);
+        const pretendErrorMiddleware = ({}: any);
+        const errorLoggerSpy = jest
+            .spyOn(ExpressWinston, "errorLogger")
+            .mockReturnValue(pretendErrorMiddleware);
+
+        // Act
+        makeErrorMiddleware(pretendLogger);
+
+        // Assert
+        expect(errorLoggerSpy).toHaveBeenCalledWith({
+            winstonInstance: pretendLogger,
+            level: "error",
+        });
+    });
+});

--- a/src/shared/__tests__/start-gateway.test.js
+++ b/src/shared/__tests__/start-gateway.test.js
@@ -22,7 +22,10 @@ describe("#start-gateway", () => {
         startGateway(options, pretendApp);
 
         // Assert
-        expect(useAppEngineMiddlewareSpy).toHaveBeenCalledWith(pretendApp);
+        expect(useAppEngineMiddlewareSpy).toHaveBeenCalledWith(
+            pretendApp,
+            options.logger,
+        );
     });
 
     it("should listen on the configured port", () => {

--- a/src/shared/__tests__/use-app-engine-middleware.test.js
+++ b/src/shared/__tests__/use-app-engine-middleware.test.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Express from "express";
+import * as MakeErrorMiddleware from "../make-error-middleware.js";
 import {useAppEngineMiddleware} from "../use-app-engine-middleware.js";
 
 jest.mock("express");
@@ -7,21 +8,7 @@ jest.mock("express");
 describe("#useAppEngineMiddleware", () => {
     it("should use the passed application", () => {
         // Arrange
-        const pretendApp = ({}: any);
-        const mockUseFn = jest.fn();
-        jest.spyOn(Express, "default").mockReturnValue({
-            use: mockUseFn,
-        });
-
-        // Act
-        useAppEngineMiddleware(pretendApp);
-
-        // Assert
-        expect(mockUseFn).toHaveBeenCalledWith(pretendApp);
-    });
-
-    it("should return the updated application", () => {
-        // Arrange
+        const pretendLogger = ({}: any);
         const pretendApp = ({}: any);
         const newApp = ({
             use: jest.fn(() => newApp),
@@ -29,7 +16,63 @@ describe("#useAppEngineMiddleware", () => {
         jest.spyOn(Express, "default").mockReturnValue(newApp);
 
         // Act
-        const result = useAppEngineMiddleware(pretendApp);
+        useAppEngineMiddleware(pretendApp, pretendLogger);
+
+        // Assert
+        expect(newApp.use).toHaveBeenCalledWith(pretendApp);
+    });
+
+    it("should add error middleware", () => {
+        // Arrange
+        const pretendLogger = ({}: any);
+        const pretendApp = ({}: any);
+        const pretendErrorMiddleware = ({}: any);
+        const newApp = ({
+            use: jest.fn(() => newApp),
+        }: any);
+        jest.spyOn(Express, "default").mockReturnValue(newApp);
+        jest.spyOn(MakeErrorMiddleware, "makeErrorMiddleware").mockReturnValue(
+            pretendErrorMiddleware,
+        );
+
+        // Act
+        useAppEngineMiddleware(pretendApp, pretendLogger);
+
+        // Assert
+        expect(newApp.use).toHaveBeenCalledWith(pretendErrorMiddleware);
+    });
+
+    it("should pass logger to error middleware", () => {
+        // Arrange
+        const pretendLogger = ({}: any);
+        const pretendApp = ({}: any);
+        const pretendErrorMiddleware = ({}: any);
+        const newApp = ({
+            use: jest.fn(() => newApp),
+        }: any);
+        jest.spyOn(Express, "default").mockReturnValue(newApp);
+        const makeErrorMiddlewareSpy = jest
+            .spyOn(MakeErrorMiddleware, "makeErrorMiddleware")
+            .mockReturnValue(pretendErrorMiddleware);
+
+        // Act
+        useAppEngineMiddleware(pretendApp, pretendLogger);
+
+        // Assert
+        expect(makeErrorMiddlewareSpy).toHaveBeenCalledWith(pretendLogger);
+    });
+
+    it("should return the updated application", () => {
+        // Arrange
+        const pretendLogger = ({}: any);
+        const pretendApp = ({}: any);
+        const newApp = ({
+            use: jest.fn(() => newApp),
+        }: any);
+        jest.spyOn(Express, "default").mockReturnValue(newApp);
+
+        // Act
+        const result = useAppEngineMiddleware(pretendApp, pretendLogger);
 
         // Assert
         expect(result).toBe(newApp);

--- a/src/shared/make-error-middleware.js
+++ b/src/shared/make-error-middleware.js
@@ -1,0 +1,20 @@
+// @flow
+import expressWinston from "express-winston";
+
+import type {Middleware, $Request, $Response} from "express";
+import type {Logger} from "./types.js";
+
+/**
+ * Create middleware for reporting errors.
+ */
+export const makeErrorMiddleware = <TReq: $Request, TRes: $Response>(
+    logger: Logger,
+): Middleware<TReq, TRes> =>
+    /**
+     * Express-winston types aren't parameterized, so we suppress the error.
+     * $FlowIgnore
+     */
+    expressWinston.errorLogger({
+        level: "error",
+        winstonInstance: logger,
+    });

--- a/src/shared/start-gateway.js
+++ b/src/shared/start-gateway.js
@@ -9,14 +9,14 @@ import type {GatewayOptions} from "./types.js";
  * This takes a server application definition and attaches middleware before
  * listening on the appropriate port per the passed options.
  */
-export const startGateway = (
+export const startGateway = <TReq: $Request, TRes: $Response>(
     options: GatewayOptions,
-    app: $Application<$Request, $Response>,
+    app: $Application<TReq, TRes>,
 ): void => {
     const {logger, port, name} = options;
 
     // Add GAE middleware.
-    const appWithMiddleware = useAppEngineMiddleware(app);
+    const appWithMiddleware = useAppEngineMiddleware(app, logger);
 
     /**
      * Start the gateway listening.

--- a/src/shared/use-app-engine-middleware.js
+++ b/src/shared/use-app-engine-middleware.js
@@ -1,19 +1,23 @@
 // @flow
 import express from "express";
-
 import type {$Application, $Request, $Response} from "express";
+import {makeErrorMiddleware} from "./make-error-middleware.js";
 
-export const useAppEngineMiddleware = (
-    app: $Application<$Request, $Response>,
+import type {Logger} from "./types.js";
+
+export const useAppEngineMiddleware = <TReq: $Request, TRes: $Response>(
+    app: $Application<TReq, TRes>,
+    logger: Logger,
     // TODO: Change this so that $Request is a type with the .log property.
     //       Once we add the request log middleware.
-): $Application<$Request, $Response> => {
+): $Application<TReq, TRes> => {
     return (
-        express()
+        express<TReq, TRes>()
             // TODO: Add request log middleware.
             // TODO: Add requestID middleware
             // Add the app.
             .use(app)
+            .use(makeErrorMiddleware<TReq, TRes>(logger))
         // TODO: Add error handling middleware.
     );
 };


### PR DESCRIPTION
This PR adds the `express-winston` error logging middleware. It also updates flow types to properly parameterize `express` things.