### PR TITLE
Part 6: Add request middleware

### DIFF
--- a/run_local.js
+++ b/run_local.js
@@ -10,13 +10,14 @@
  */
 const {
     runServer,
-    KAShared: {getLogger},
+    KAShared: {getLogger, getRuntimeMode},
 } = require("./src/index.js");
 
 async function main() {
     runServer({
         name: "DEV_LOCAL",
         port: 8080,
+        mode: getRuntimeMode(),
         logger: getLogger(),
     });
 }

--- a/src/ka-shared/__tests__/index.test.js
+++ b/src/ka-shared/__tests__/index.test.js
@@ -8,6 +8,8 @@ describe("index.js", () => {
         const result = await importedModule;
 
         // Assert
-        expect(Object.keys(result).sort()).toEqual(["getLogger"].sort());
+        expect(Object.keys(result).sort()).toEqual(
+            ["getLogger", "getRuntimeMode"].sort(),
+        );
     });
 });

--- a/src/ka-shared/index.js
+++ b/src/ka-shared/index.js
@@ -1,2 +1,3 @@
 // @flow
 export {getLogger} from "./get-logger.js";
+export {getRuntimeMode} from "./get-runtime-mode.js";

--- a/src/shared/__tests__/make-request-middleware.test.js
+++ b/src/shared/__tests__/make-request-middleware.test.js
@@ -1,0 +1,103 @@
+// @flow
+import * as ExpressWinston from "express-winston";
+import * as LoggingWinston from "@google-cloud/logging-winston";
+import {makeRequestMiddleware} from "../make-request-middleware.js";
+
+jest.mock("express-winston");
+jest.mock("@google-cloud/logging-winston", () => ({
+    LoggingWinston: function() {
+        const localWinston = jest.requireActual("winston");
+        /**
+         * The full LoggingWinston type will cause tests to hang weirdly, so we
+         * return a console one but add our little identifier to indicate it
+         * is fake.
+         */
+        const fakeLoggingWinston = new localWinston.transports.Console();
+        // We made this up for testing purposes. $FlowIgnore
+        fakeLoggingWinston.__FAKE_LOGGING_WINSTON__ = true;
+        return fakeLoggingWinston;
+    },
+    express: {
+        makeMiddleware: jest.fn(),
+    },
+}));
+
+describe("#makeRequestMiddleware", () => {
+    describe("when in production", () => {
+        it("should return logging-winston middleware", async () => {
+            // Arrange
+            const pretendLogger = ({}: any);
+            const pretendLoggingWinstonMiddleware = ({}: any);
+            jest.spyOn(
+                LoggingWinston.express,
+                "makeMiddleware",
+            ).mockReturnValue(pretendLoggingWinstonMiddleware);
+
+            // Act
+            const result = await makeRequestMiddleware(
+                "production",
+                pretendLogger,
+            );
+
+            // Assert
+            expect(result).toBe(pretendLoggingWinstonMiddleware);
+        });
+
+        it("should create middleware with logger and transport", async () => {
+            // Arrange
+            const pretendLogger = ({}: any);
+            const pretendLoggingWinstonMiddleware = ({}: any);
+            const middlewareSpy = jest
+                .spyOn(LoggingWinston.express, "makeMiddleware")
+                .mockReturnValue(pretendLoggingWinstonMiddleware);
+
+            // Act
+            await makeRequestMiddleware("production", pretendLogger);
+
+            // Assert
+            expect(middlewareSpy).toHaveBeenCalledWith(
+                pretendLogger,
+                expect.objectContaining({__FAKE_LOGGING_WINSTON__: true}),
+            );
+        });
+    });
+
+    describe("when not in production", () => {
+        it("should return express-winston middleware", async () => {
+            // Arrange
+            const pretendLogger = ({}: any);
+            const pretendExpressWinstonMiddleware = ({}: any);
+            jest.spyOn(ExpressWinston, "logger").mockReturnValue(
+                pretendExpressWinstonMiddleware,
+            );
+
+            // Act
+            const result = await makeRequestMiddleware(
+                "development",
+                pretendLogger,
+            );
+
+            // Assert
+            expect(result).toBe(pretendExpressWinstonMiddleware);
+        });
+
+        it("should create middleware with logger", async () => {
+            // Arrange
+            const pretendLogger = ({}: any);
+            const pretendExpressWinstonMiddleware = ({}: any);
+            const middlewareSpy = jest
+                .spyOn(ExpressWinston, "logger")
+                .mockReturnValue(pretendExpressWinstonMiddleware);
+
+            // Act
+            await makeRequestMiddleware("production", pretendLogger);
+
+            // Assert
+            expect(middlewareSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    winstonInstance: pretendLogger,
+                }),
+            );
+        });
+    });
+});

--- a/src/shared/__tests__/start-gateway.test.js
+++ b/src/shared/__tests__/start-gateway.test.js
@@ -4,36 +4,39 @@ import {startGateway} from "../start-gateway.js";
 import {createLogger} from "../create-logger.js";
 
 describe("#start-gateway", () => {
-    it("should add GAE middleware", () => {
+    it("should add GAE middleware", async () => {
         // Arrange
         const options = {
             name: "TEST_GATEWAY",
             port: 42,
             logger: createLogger("test", "debug"),
+            mode: "test",
         };
         const pretendApp = ({
             listen: jest.fn(),
         }: any);
         const useAppEngineMiddlewareSpy = jest
             .spyOn(UseAppEngineMiddleware, "useAppEngineMiddleware")
-            .mockReturnValue(pretendApp);
+            .mockReturnValue(Promise.resolve(pretendApp));
 
         // Act
-        startGateway(options, pretendApp);
+        await startGateway(options, pretendApp);
 
         // Assert
         expect(useAppEngineMiddlewareSpy).toHaveBeenCalledWith(
             pretendApp,
+            "test",
             options.logger,
         );
     });
 
-    it("should listen on the configured port", () => {
+    it("should listen on the configured port", async () => {
         // Arrange
         const options = {
             name: "TEST_GATEWAY",
             port: 42,
             logger: createLogger("test", "debug"),
+            mode: "test",
         };
         const pretendApp = ({
             listen: jest.fn(),
@@ -41,10 +44,10 @@ describe("#start-gateway", () => {
         jest.spyOn(
             UseAppEngineMiddleware,
             "useAppEngineMiddleware",
-        ).mockReturnValue(pretendApp);
+        ).mockReturnValue(Promise.resolve(pretendApp));
 
         // Act
-        startGateway(options, pretendApp);
+        await startGateway(options, pretendApp);
 
         // Assert
         expect(pretendApp.listen).toHaveBeenCalledWith(
@@ -54,12 +57,13 @@ describe("#start-gateway", () => {
     });
 
     describe("listen callback", () => {
-        it("should report start failure if gateway is null", () => {
+        it("should report start failure if gateway is null", async () => {
             // Arrange
             const options = {
                 name: "TEST_GATEWAY",
                 port: 42,
                 logger: createLogger("test", "debug"),
+                mode: "test",
             };
             const listenMock = jest.fn().mockReturnValue(null);
             const pretendApp = ({
@@ -68,8 +72,8 @@ describe("#start-gateway", () => {
             jest.spyOn(
                 UseAppEngineMiddleware,
                 "useAppEngineMiddleware",
-            ).mockReturnValue(pretendApp);
-            startGateway(options, pretendApp);
+            ).mockReturnValue(Promise.resolve(pretendApp));
+            await startGateway(options, pretendApp);
             const errorSpy = jest.spyOn(options.logger, "error");
             const listenCallback = listenMock.mock.calls[0][1];
 
@@ -82,12 +86,13 @@ describe("#start-gateway", () => {
             );
         });
 
-        it("should report start failure if there's an error", () => {
+        it("should report start failure if there's an error", async () => {
             // Arrange
             const options = {
                 name: "TEST_GATEWAY",
                 port: 42,
                 logger: createLogger("test", "debug"),
+                mode: "test",
             };
             const listenMock = jest.fn().mockReturnValue(null);
             const pretendApp = ({
@@ -96,8 +101,8 @@ describe("#start-gateway", () => {
             jest.spyOn(
                 UseAppEngineMiddleware,
                 "useAppEngineMiddleware",
-            ).mockReturnValue(pretendApp);
-            startGateway(options, pretendApp);
+            ).mockReturnValue(Promise.resolve(pretendApp));
+            await startGateway(options, pretendApp);
             const errorSpy = jest.spyOn(options.logger, "error");
             const listenCallback = listenMock.mock.calls[0][1];
 
@@ -112,12 +117,13 @@ describe("#start-gateway", () => {
 
         it.each([[null, undefined, "ADDRESS"]])(
             "should report start failure if address is %s",
-            (address) => {
+            async (address) => {
                 // Arrange
                 const options = {
                     name: "TEST_GATEWAY",
                     port: 42,
                     logger: createLogger("test", "debug"),
+                    mode: "test",
                 };
                 const fakeServer = {
                     address: () => address,
@@ -129,8 +135,8 @@ describe("#start-gateway", () => {
                 jest.spyOn(
                     UseAppEngineMiddleware,
                     "useAppEngineMiddleware",
-                ).mockReturnValue(pretendApp);
-                startGateway(options, pretendApp);
+                ).mockReturnValue(Promise.resolve(pretendApp));
+                await startGateway(options, pretendApp);
                 const warnSpy = jest.spyOn(options.logger, "warn");
                 const listenCallback = listenMock.mock.calls[0][1];
 
@@ -144,12 +150,13 @@ describe("#start-gateway", () => {
             },
         );
 
-        it("should report a successful start", () => {
+        it("should report a successful start", async () => {
             // Arrange
             const options = {
                 name: "TEST_GATEWAY",
                 port: 42,
                 logger: createLogger("test", "debug"),
+                mode: "test",
             };
             const fakeServer = {
                 address: () => ({
@@ -164,8 +171,8 @@ describe("#start-gateway", () => {
             jest.spyOn(
                 UseAppEngineMiddleware,
                 "useAppEngineMiddleware",
-            ).mockReturnValue(pretendApp);
-            startGateway(options, pretendApp);
+            ).mockReturnValue(Promise.resolve(pretendApp));
+            await startGateway(options, pretendApp);
             const infoSpy = jest.spyOn(options.logger, "info");
             const listenCallback = listenMock.mock.calls[0][1];
 

--- a/src/shared/make-request-middleware.js
+++ b/src/shared/make-request-middleware.js
@@ -1,0 +1,48 @@
+// @flow
+import * as lw from "@google-cloud/logging-winston";
+import expressWinston from "express-winston";
+
+import type {Middleware, $Request, $Response} from "express";
+import type {Logger, Runtime} from "./types.js";
+
+/**
+ * Create middleware for tracking requests.
+ */
+export const makeRequestMiddleware = <TReq: $Request, TRes: $Response>(
+    mode: Runtime,
+    logger: Logger,
+): Promise<Middleware<TReq, TRes>> => {
+    if (mode === "production") {
+        /**
+         * In production, we're using the Google middleware. This adds the
+         * log property to the request, allowing us to associate log entries
+         * with a request trace, if the request is being traced.
+         *
+         * WORKAROUND: We must pass the corresponding transport here or it will
+         * get added for us and then we'll have double logging.
+         */
+        return lw.express.makeMiddleware(logger, new lw.LoggingWinston());
+    }
+
+    /**
+     * In all other cases, we use express-winston to log requests for us.
+     */
+    return Promise.resolve(
+        expressWinston.logger({
+            /**
+             * Specify the level that this logger logs at.
+             * (use a function to dynamically change level based on req and res)
+             *     `function(req, res) { return String; }`
+             */
+            level: "info",
+
+            /**
+             * Use the logger we already set up.
+             */
+            winstonInstance: logger,
+            expressFormat: true,
+            colorize: true,
+            meta: false,
+        }),
+    );
+};

--- a/src/shared/start-gateway.js
+++ b/src/shared/start-gateway.js
@@ -1,7 +1,7 @@
 // @flow
 import type {$Application, $Request, $Response} from "express";
 import {useAppEngineMiddleware} from "./use-app-engine-middleware.js";
-import type {GatewayOptions} from "./types.js";
+import type {GatewayOptions, RequestWithLog} from "./types.js";
 
 /**
  * Start a gateway application server.
@@ -9,14 +9,18 @@ import type {GatewayOptions} from "./types.js";
  * This takes a server application definition and attaches middleware before
  * listening on the appropriate port per the passed options.
  */
-export const startGateway = <TReq: $Request, TRes: $Response>(
-    options: GatewayOptions,
-    app: $Application<TReq, TRes>,
-): void => {
-    const {logger, port, name} = options;
+export async function startGateway<
+    TReq: RequestWithLog<$Request>,
+    TRes: $Response,
+>(options: GatewayOptions, app: $Application<TReq, TRes>): Promise<void> {
+    const {logger, port, name, mode} = options;
 
     // Add GAE middleware.
-    const appWithMiddleware = useAppEngineMiddleware(app, logger);
+    const appWithMiddleware = await useAppEngineMiddleware<TReq, TRes>(
+        app,
+        mode,
+        logger,
+    );
 
     /**
      * Start the gateway listening.
@@ -43,4 +47,4 @@ export const startGateway = <TReq: $Request, TRes: $Response>(
         const port = address.port;
         logger.info(`${name} running at http://${host}:${port}`);
     });
-};
+}

--- a/src/shared/types.js
+++ b/src/shared/types.js
@@ -4,6 +4,7 @@ import type {
     Logger as WinstonLogger,
     Info as WinstonInfo,
 } from "winston";
+import type {$Request} from "express";
 
 export type Info = WinstonInfo<NpmLogLevels>;
 export type LogLevel = $Keys<NpmLogLevels>;
@@ -13,4 +14,8 @@ export type GatewayOptions = {
     name: string,
     port: number,
     logger: Logger,
+    mode: Runtime,
+};
+export type RequestWithLog<TReq: $Request> = TReq & {
+    log?: Logger,
 };

--- a/src/shared/use-app-engine-middleware.js
+++ b/src/shared/use-app-engine-middleware.js
@@ -2,22 +2,26 @@
 import express from "express";
 import type {$Application, $Request, $Response} from "express";
 import {makeErrorMiddleware} from "./make-error-middleware.js";
+import {makeRequestMiddleware} from "./make-request-middleware.js";
 
-import type {Logger} from "./types.js";
+import type {Logger, Runtime} from "./types.js";
 
-export const useAppEngineMiddleware = <TReq: $Request, TRes: $Response>(
+/**
+ * Apply the middleware that we want to use with Google App Engine (GAE).
+ */
+export async function useAppEngineMiddleware<TReq: $Request, TRes: $Response>(
     app: $Application<TReq, TRes>,
+    mode: Runtime,
     logger: Logger,
-    // TODO: Change this so that $Request is a type with the .log property.
-    //       Once we add the request log middleware.
-): $Application<TReq, TRes> => {
+): Promise<$Application<TReq, TRes>> {
     return (
         express<TReq, TRes>()
-            // TODO: Add request log middleware.
+            // Add the request logging middleware.
+            .use(await makeRequestMiddleware<TReq, TRes>(mode, logger))
             // TODO: Add requestID middleware
             // Add the app.
             .use(app)
+            // Add the error logging middleware.
             .use(makeErrorMiddleware<TReq, TRes>(logger))
-        // TODO: Add error handling middleware.
     );
-};
+}


### PR DESCRIPTION
This adds the LoggingWinston middleware that allows us to group log entries by traceID when viewing logs in StackDriver. 