### PR TITLE
Part 7: Update getLogger to support request.log

### DIFF
--- a/src/ka-shared/__tests__/get-logger.test.js
+++ b/src/ka-shared/__tests__/get-logger.test.js
@@ -35,7 +35,7 @@ describe("get-logger.js", () => {
     });
 
     describe("#getLogger", () => {
-        it("should return the logger created on import", async () => {
+        it("should return the logger created on import when there is no request", async () => {
             // Arrange
             const {getLogger} = await import("../get-logger.js");
 
@@ -44,6 +44,32 @@ describe("get-logger.js", () => {
 
             // Assert
             expect(result).toBe(fakeLogger);
+        });
+
+        it("should return the logger created on import when the request has no log", async () => {
+            // Arrange
+            const {getLogger} = await import("../get-logger.js");
+
+            // Act
+            const result = getLogger(({}: any));
+
+            // Assert
+            expect(result).toBe(fakeLogger);
+        });
+
+        it("should return the request logger when the request has a log", async () => {
+            // Arrange
+            const {getLogger} = await import("../get-logger.js");
+            const pretendRequestLogger = ({}: any);
+            const pretendRequest = ({
+                log: pretendRequestLogger,
+            }: any);
+
+            // Act
+            const result = getLogger(pretendRequest);
+
+            // Assert
+            expect(result).toBe(pretendRequestLogger);
         });
     });
 });

--- a/src/ka-shared/get-logger.js
+++ b/src/ka-shared/get-logger.js
@@ -1,8 +1,9 @@
 // @flow
+import type {$Request} from "express";
 import {createLogger} from "../shared/index.js";
 import {getRuntimeMode} from "./get-runtime-mode.js";
 import {getLogLevel} from "./get-log-level.js";
-import type {Logger} from "../shared/index.js";
+import type {Logger, RequestWithLog} from "../shared/index.js";
 
 /**
  * Create our top-level logger on module import so that all importers of this
@@ -13,6 +14,18 @@ const rootLogger = createLogger(getRuntimeMode(), getLogLevel());
 /**
  * Get the logger to use in the current context.
  *
- * TODO(somewhatabstract): Update to support request-scoped loggers
+ * When given a request, if that request has a log property, then that logger
+ * is returned, otherwise the top-level logger instance is returned. This
+ * provides a convenience so that the calling code does not need to know the
+ * source of the logger.
+ *
+ * There is no need for a logger to specifically request the top-level logger
+ * as things that are logging should not care. However, in a case where there
+ * is no request to use for context, it is equivalent to explicitly requesting
+ * the top-level logger. To put it another way, there is no need for a semantic
+ * use of getTopLevelLogger as that is not a real use-case.
  */
-export const getLogger = (): Logger => rootLogger;
+export const getLogger = <TReq: RequestWithLog<$Request>>(
+    request?: TReq,
+): Logger =>
+    request != null && request.log != null ? request.log : rootLogger;

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,5 +1,11 @@
 // @flow
-export type {Runtime, LogLevel, Logger, GatewayOptions} from "./types.js";
+export type {
+    Runtime,
+    LogLevel,
+    Logger,
+    GatewayOptions,
+    RequestWithLog,
+} from "./types.js";
 
 export {createLogger} from "./create-logger.js";
 export {getRuntimeMode} from "./get-runtime-mode.js";


### PR DESCRIPTION
This updates `getLogger` to support the `request.log` property that the google middleware adds.