### PR TITLE
Make sure things work right when pushing

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -87,7 +87,6 @@ jobs:
         echo ::set-env name=PUBLISH_BRANCH::$_PUBLISH_BRANCH
 
     - name: Checkout via SSH
-      if: github.event_name == 'pull_request'
       run: git checkout ${{ env.PUBLISH_BRANCH }}
     - name: Use Node.js 12
       uses: actions/setup-node@v1


### PR DESCRIPTION
This modifies things so that for push events, we base the branch off the current ref. This also makes sure that if we have no branch, we abort, rather than continue - otherwise, we would run `git checkout`, which on a cleanly cloned repo like what we're using is the default branch, `master`.

# Test Plan

This PR should test the PR flow. Then I'll merge the changes post review and delete the `dist` folder from the feature branch and push that change to test the push flow.