### PR TITLE
Add support for optional chaining

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -11,6 +11,9 @@ module.exports = {
         ],
         "@babel/preset-flow",
     ],
-    plugins: ["@babel/plugin-proposal-class-properties"],
+    plugins: [
+        "@babel/plugin-proposal-class-properties",
+        "@babel/plugin-proposal-optional-chaining",
+    ],
     sourceMaps: true,
 };

--- a/.flowconfig
+++ b/.flowconfig
@@ -24,6 +24,7 @@ implicit-inexact-object=error
 emoji=true
 exact_by_default=true
 module.use_strict=true
+esproposal.optional_chaining=enable
 
 # $FlowFixMe
 # This suppression hould be used to suppress an issue that requires additional

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/preset-env": "^7.8.7",
     "@babel/preset-flow": "^7.8.3",
     "@khanacademy/eslint-config": "^0.0.5",


### PR DESCRIPTION
# Summary

Adds optional chaining (Stage 4 feature proposal) support to babel and flow.

This will make working with gateway options nicer when those options are ...optional.

The code that is coming up makes use of this, just splitting things out into smaller diffs.