### PR TITLE
[WEB-2443].1 Create examples

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,8 +13,8 @@ implicit-inexact-object=error
 <PROJECT_ROOT>/bin
 
 [include]
-run_local.js
 src
+examples
 .*/__tests__/.*
 
 [libs]

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,4 +22,4 @@ ignore:
   - "dist"
   - "**/types.js"
   - "tools"
-  - "run_local.js"
+  - "examples"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Examples
+
+Each folder in this location must contain a file named `run.js` that is
+responsible for executing the given example. To execute an example, you can
+run the following command from the root folder, where `<EXAMPLE>` is the name
+of the example folder.
+
+```shell
+yarn start:example <EXAMPLE>
+```

--- a/examples/echo-environment/run.js
+++ b/examples/echo-environment/run.js
@@ -8,8 +8,8 @@
  * NOTE: We import everything from index.js to ensure we're testing the public
  * interface of this package.
  */
-const {runServer} = require("./src/gateway/index.js");
-/*:: import type {RenderAPI, RenderResult} from "./src/gateway/index.js"; */
+const {runServer} = require("../../src/gateway/index.js");
+/*:: import type {RenderAPI, RenderResult} from "../../src/gateway/index.js"; */
 
 async function main() {
     const renderEnvironment = {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "KA_LOG_LEVEL=silly NODE_ENV=development babel-watch run_local.js",
+    "start:example": "bash -c 'RUNNER=\"./examples/$0/run.js\"; KA_LOG_LEVEL=silly NODE_ENV=development babel-watch \"$RUNNER\"'",
+    "start": "yarn start:example echo-environment",
     "clean": "rm -rf dist",
-    "test": "jest --colors --config jest.config.js src",
+    "test": "jest --colors --config jest.config.js",
     "coverage": "jest --colors --config jest.config.js --coverage",
-    "lint:all": "yarn lint \"{run_local.js,src,bin,__{tests,mocks}__}/**/*.js\"",
+    "lint:all": "yarn lint \"{examples,src,bin,__{tests,mocks}__}/**/*.js\"",
     "lint": "eslint --report-unused-disable-directives --config .eslintrc.js --ignore-path .eslintignore",
     "flow:ci": "flow check",
     "build:noclean": "babel src --out-dir dist --source-maps --config-file ./.babelrc.js --ignore \"**/__tests__/**/*.js\",\"**/__mocks__/**/*.js\"",


### PR DESCRIPTION
## Summary

*DEV ONLY CHANGE*

This creates the concept of *Examples* and moves what was `run_local.js` to be our first example. The idea is that we can add other examples and then easily execute one via the `yarn start:example <example>` command.

I have mapped `yarn start` to `yarn start:example echo-environment` to retain the functionality we had prior to this change.

## Issues

WEB-2443
