### PR TITLE
Remove inflight request sharing

### DIFF
--- a/src/gateway/__tests__/index.test.js
+++ b/src/gateway/__tests__/index.test.js
@@ -23,10 +23,6 @@ describe("index.js", () => {
         const {Requests: result} = await importedModule;
 
         // Assert
-        expect(result).toContainAllKeys([
-            "request",
-            "abortInFlightRequests",
-            "DefaultRequestOptions",
-        ]);
+        expect(result).toContainAllKeys(["request", "DefaultRequestOptions"]);
     });
 });

--- a/src/gateway/__tests__/request.test.js
+++ b/src/gateway/__tests__/request.test.js
@@ -2,87 +2,13 @@
 import * as Shared from "../../shared/index.js";
 import * as MakeRequest from "../make-request.js";
 import * as RequestsFromCache from "../requests-from-cache.js";
-import {request, abortInFlightRequests} from "../request.js";
+import {request} from "../request.js";
 
 jest.mock("../../shared/index.js");
 jest.mock("../make-request.js");
 jest.mock("../requests-from-cache.js");
 
-describe("#abortInFlightRequests", () => {
-    beforeEach(() => {
-        /**
-         * Some test cases might add to the in-flight list.
-         * Let's make sure it gets cleared.
-         */
-        abortInFlightRequests();
-    });
-
-    it("should call abort on requests", () => {
-        // Arrange
-        const fakeOptions: any = "FAKE_OPTIONS";
-        const fakeLogger: any = "FAKE_LOGGER";
-        const fakeRequest: any = {
-            abort: jest.fn().mockReturnThis(),
-            then: jest.fn().mockReturnThis(),
-            finally: jest.fn().mockReturnThis(),
-        };
-        const fakeTraceSession: any = {
-            addLabel: jest.fn(),
-            end: jest.fn(),
-        };
-        jest.spyOn(Shared, "trace").mockReturnValue(fakeTraceSession);
-        jest.spyOn(MakeRequest, "makeRequest").mockReturnValue(fakeRequest);
-        request(fakeLogger, "URL", fakeOptions);
-
-        // Act
-        abortInFlightRequests();
-
-        // Assert
-        expect(fakeRequest.abort).toHaveBeenCalledTimes(1);
-    });
-
-    it("should remove requests from the in-flight list", () => {
-        // Arrange
-        const fakeOptions: any = "FAKE_OPTIONS";
-        const fakeLogger: any = "FAKE_LOGGER";
-        const fakeRequest: any = {
-            abort: jest.fn().mockReturnThis(),
-            then: jest.fn().mockReturnThis(),
-            finally: jest.fn().mockReturnThis(),
-        };
-        const fakeRequest2: any = {
-            abort: jest.fn().mockReturnThis(),
-            then: jest.fn().mockReturnThis(),
-            finally: jest.fn().mockReturnThis(),
-        };
-        const fakeTraceSession: any = {
-            addLabel: jest.fn(),
-            end: jest.fn(),
-        };
-        jest.spyOn(Shared, "trace").mockReturnValue(fakeTraceSession);
-        jest.spyOn(MakeRequest, "makeRequest")
-            .mockReturnValueOnce(fakeRequest)
-            .mockReturnValue(fakeRequest2);
-        request(fakeLogger, "URL", fakeOptions);
-
-        // Act
-        abortInFlightRequests();
-        const result = request(fakeLogger, "URL", fakeOptions);
-
-        // Assert
-        expect(result).toBe(fakeRequest2);
-    });
-});
-
 describe("#request", () => {
-    beforeEach(() => {
-        /**
-         * Some test cases might add to the in-flight list.
-         * Let's make sure it gets cleared.
-         */
-        abortInFlightRequests();
-    });
-
     it("should start a trace", () => {
         // Arrange
         const fakeOptions: any = "FAKE_OPTIONS";
@@ -187,91 +113,6 @@ describe("#request", () => {
         jest.spyOn(MakeRequest, "makeRequest").mockReturnValue(fakeRequest);
 
         // Act
-        const result = request(fakeLogger, "URL", fakeOptions);
-
-        // Assert
-        expect(result).toBe(fakeRequest);
-    });
-
-    it("should return in-flight request if one is in-flight", () => {
-        // Arrange
-        const fakeOptions: any = "FAKE_OPTIONS";
-        const fakeLogger: any = "FAKE_LOGGER";
-        const fakeRequest: any = {
-            abort: jest.fn().mockReturnThis(),
-            then: jest.fn().mockReturnThis(),
-            finally: jest.fn().mockReturnThis(),
-        };
-        const fakeTraceSession: any = {
-            addLabel: jest.fn(),
-            end: jest.fn(),
-        };
-        jest.spyOn(Shared, "trace").mockReturnValue(fakeTraceSession);
-        jest.spyOn(MakeRequest, "makeRequest").mockReturnValueOnce(fakeRequest);
-
-        // Act
-        request(fakeLogger, "URL", fakeOptions);
-        const result = request(fakeLogger, "URL", fakeOptions);
-
-        // Assert
-        expect(result).toBe(fakeRequest);
-    });
-
-    it("should delete rejected requests from in-flight list", async () => {
-        // Arrange
-        const fakeOptions: any = "FAKE_OPTIONS";
-        const fakeLogger: any = "FAKE_LOGGER";
-        const fakeRequest: any = {
-            abort: jest.fn().mockReturnThis(),
-            then: jest.fn().mockReturnThis(),
-            finally: jest.fn().mockReturnThis(),
-        };
-        const fakeTraceSession: any = {
-            addLabel: jest.fn(),
-            end: jest.fn(),
-        };
-        const rejectedRequest: any = Promise.reject("OOPS!");
-        rejectedRequest.abort = jest.fn();
-        jest.spyOn(MakeRequest, "makeRequest")
-            .mockReturnValueOnce(rejectedRequest)
-            .mockReturnValueOnce(fakeRequest);
-        jest.spyOn(Shared, "trace").mockReturnValue(fakeTraceSession);
-
-        // Act
-        let result;
-        try {
-            await request(fakeLogger, "URL", fakeOptions);
-        } catch (e) {
-            expect(e).toBe("OOPS!");
-            result = request(fakeLogger, "URL", fakeOptions);
-        }
-
-        // Assert
-        expect(result).toBe(fakeRequest);
-    });
-
-    it("should delete resolved requests from in-flight list", async () => {
-        // Arrange
-        const fakeOptions: any = "FAKE_OPTIONS";
-        const fakeLogger: any = "FAKE_LOGGER";
-        const fakeRequest: any = {
-            abort: jest.fn().mockReturnThis(),
-            then: jest.fn().mockReturnThis(),
-            finally: jest.fn().mockReturnThis(),
-        };
-        const fakeTraceSession: any = {
-            addLabel: jest.fn(),
-            end: jest.fn(),
-        };
-        const resolvedRequest: any = Promise.resolve("YAY!");
-        resolvedRequest.abort = jest.fn();
-        jest.spyOn(MakeRequest, "makeRequest")
-            .mockReturnValueOnce(resolvedRequest)
-            .mockReturnValueOnce(fakeRequest);
-        jest.spyOn(Shared, "trace").mockReturnValue(fakeTraceSession);
-
-        // Act
-        await request(fakeLogger, "URL", fakeOptions);
         const result = request(fakeLogger, "URL", fakeOptions);
 
         // Assert

--- a/src/gateway/environments/jsdom-sixteen/__tests__/jsdom-sixteen-resource-loader.test.js
+++ b/src/gateway/environments/jsdom-sixteen/__tests__/jsdom-sixteen-resource-loader.test.js
@@ -72,22 +72,6 @@ describe("JSDOMSixteenResourceLoader", () => {
     });
 
     describe("#close", () => {
-        it("should abort inflight requests", () => {
-            // Arrange
-            const abortInFlightRequestsSpy = jest.spyOn(
-                Request,
-                "abortInFlightRequests",
-            );
-            const fakeRenderAPI: any = {};
-            const underTest = new JSDOMSixteenResourceLoader(fakeRenderAPI);
-
-            // Act
-            underTest.close();
-
-            // Assert
-            expect(abortInFlightRequestsSpy).toHaveBeenCalled();
-        });
-
         it("should set isActive to false", () => {
             // Arrange
             const fakeRenderAPI: any = {};

--- a/src/gateway/environments/jsdom-sixteen/jsdom-sixteen-resource-loader.js
+++ b/src/gateway/environments/jsdom-sixteen/jsdom-sixteen-resource-loader.js
@@ -5,11 +5,7 @@ import type {Agent as HttpsAgent} from "https";
 import {ResourceLoader} from "jsdom";
 import type {FetchOptions} from "jsdom";
 import {getAgentForURL} from "../../../shared/index.js";
-import {
-    DefaultRequestOptions,
-    request,
-    abortInFlightRequests,
-} from "../../request.js";
+import {DefaultRequestOptions, request} from "../../request.js";
 import {applyAbortablePromisesPatch} from "./apply-abortable-promises-patch.js";
 
 import type {RequestOptions, RenderAPI} from "../../types.js";
@@ -98,7 +94,6 @@ export class JSDOMSixteenResourceLoader extends ResourceLoader {
 
     close(): void {
         this._active = false;
-        abortInFlightRequests();
 
         /**
          * We need to destroy any agents we created or they may retain

--- a/src/gateway/types.js
+++ b/src/gateway/types.js
@@ -2,25 +2,13 @@
 import type {Agent as HttpAgent} from "http";
 import type {Agent as HttpsAgent} from "https";
 import type {$Request, $Response} from "express";
-import type {
-    CallbackHandler,
-    Plugin,
-    Response as SuperAgentResponse,
-} from "superagent";
+import type {CallbackHandler, Plugin} from "superagent";
 import type {
     RequestWithLog,
     ITraceSession,
     Logger,
     SimplifiedError,
 } from "../shared/index.js";
-
-/**
- * Used to track inflight requests.
- */
-export type InFlightRequests = {
-    [url: string]: AbortablePromise<SuperAgentResponse>,
-    ...
-};
 
 /**
  * Options for configuring incoming request authentication.


### PR DESCRIPTION
Sharing inflight requests was a carry over from the RRS and it turns
out it really isn't helping us.

1. We need to destroy agents that make the requests once a render is over but if another request is sharing that agent's request, we lost that request
2. JSDOM aborts inflight requests on close, but if those are shared with other renders, you can see what would happen.

So, let's just not do that.

## Summary:

Issue: WEB-2631

## Test plan:

Run the gateway with webapp and make some requests to see that they still work.