### PR TITLE
[FEI-2726].7 Retry tweaks

### DIFF
--- a/src/gateway/make-should-retry.js
+++ b/src/gateway/make-should-retry.js
@@ -23,7 +23,12 @@ export const makeShouldRetry = (
          * log that the request failed if we don't have an error object.
          */
         if (err != null) {
-            logger.warn("Request failed. Might retry.", {
+            if (logger.defaultMeta != null) {
+                logger.defaultMeta.retries += 1;
+            }
+            // We log at the lowest level as usually we don't care about this
+            // as long as we ultimately succeed.
+            logger.silly("Request failed. Might retry.", {
                 ...extractError(err),
                 code: (err: any).code,
                 status: res?.status,

--- a/src/gateway/make-unbuffered-no-cache-request.js
+++ b/src/gateway/make-unbuffered-no-cache-request.js
@@ -24,6 +24,7 @@ export const makeUnbufferedNoCacheRequest = (
     const {name, version} = getGatewayInfo();
     const requestLogger = logger.child({
         requestedURL: url,
+        retries: 0,
     });
 
     return (


### PR DESCRIPTION
## Summary:
This tweaks our retry logging to not log noisily in prod but to track the retry count in the logged data (which should then make it as a label in an trace charts that get made)


Issue: FEI-2726

## Test plan: