### PR TITLE
Target Node16 instead of 14 for our tests

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x]
+        node-version: [12.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 16.x]
         exclude:
           # The publish job covers this configuration
           - os: ubuntu-latest


### PR DESCRIPTION
## Summary:
This is a precursor to making sure we can use Node 16 as our base dev platform. By adding this here we can verify that it should be fine and then we can update the consumed version of this repo and test it all out.

Issue: FEI-4348

## Test plan:
Check that the action runs succesfully.